### PR TITLE
Jc/add tether

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'devise'
 
 gem 'bootstrap', '~> 4.0.0.alpha3'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-tether', '>= 1.1.0'
+end
 
 gem 'jquery-rails'
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.2.6)
       actionpack (= 4.2.6)
@@ -114,6 +115,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.6)
       sprockets-rails
+    rails-assets-tether (1.1.1)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -202,6 +204,7 @@ DEPENDENCIES
   jquery-rails
   pg
   rails (= 4.2.6)
+  rails-assets-tether (>= 1.1.0)!
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
-//= require jquery
+//= require tether
 //= require bootstrap
 //= require_tree .


### PR DESCRIPTION
Adds rails-assets-tether gem which adds tether.js. This is required by bootstrap tooltips and breaks JS when missing.
