### PR TITLE
Ability to select more than one facility expertise

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -81,6 +81,13 @@ class FacilitiesController < ApplicationController
         :name,
         :approved,
         :facility_type_id,
+        :spa,
+        :acreage,
+        :endangered_acreage,
+        :temperture_controled,
+        :water_features,
+        :supplemental_feed,
+        expertise: [],
         interests: [],
         pictures_attributes: [:name, :image],
         facilities_users_attributes: [:user_id, :facility_id]

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -4,8 +4,7 @@ class Facility < ActiveRecord::Base
   has_many :users, through: :facilities_users
   has_many :pictures, :dependent => :destroy
   belongs_to :facility_type
-  belongs_to :facility_expertise
-
+  
   accepts_nested_attributes_for :facilities_users
 
   validates :name, presence: true
@@ -32,5 +31,9 @@ class Facility < ActiveRecord::Base
 
   VALID_INTERESTS.keys.each do |interest|
     define_method("interest_to_#{interest}?"){ interests.include?(interest) }
+  end
+
+  FacilityExpertise.all.each do |expertise|
+    define_method("expertise_to_#{expertise.id}?"){ expertise.include?(expertise.id)}
   end
 end

--- a/app/views/animals/_form.html.erb
+++ b/app/views/animals/_form.html.erb
@@ -16,7 +16,6 @@
   <%= f.input :dam, label: 'Dam' %>
   <%= f.input :tag %>
   <%= f.input :searchable %>
-  <%= f.input :searchable %>
   <%= f.input :comments %>
   <%= f.label :images %>
   <br/>

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -4,7 +4,7 @@
   	<%= fu.input :user_id, input_html: { value: current_user.id }, :as => :hidden %>
   <% end %>
   <%= f.input :name %>
-  <%= f.input :facility_type_id, collection: FacilityType.all %>
+  <%= f.input :facility_type_id,  as: :radio_buttons, collection: FacilityType.all %>
   <div class="form-group check_boxes optional facility_interests">
     <%= f.simple_fields_for :pictures do |p| %>
       <%= p.label :image %>
@@ -15,7 +15,7 @@
 
   <%= f.input :interests, as: :check_boxes, collection: Facility::VALID_INTERESTS.to_a.map(&:reverse) %>
 
-  <%= f.input :facility_expertise_id, collection: FacilityExpertise.all %>
+  <%= f.input :expertise, as: :check_boxes, collection: FacilityExpertise.all.map{|f| [f.name, f.id.to_s]} %>
   <%= f.input :spa %>
   <%= f.input :acreage %>
   <%= f.input :endangered_acreage %>

--- a/db/migrate/20160630013339_change_facility_interests_to_a_list.rb
+++ b/db/migrate/20160630013339_change_facility_interests_to_a_list.rb
@@ -1,0 +1,7 @@
+class ChangeFacilityInterestsToAList < ActiveRecord::Migration
+  def change
+    remove_index :facilities, name: "index_facilities_on_facility_expertise_id"
+    remove_column :facilities, :facility_expertise_id
+    add_column :facilities, :expertise, :text, default: [], array: true 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160619145037) do
+ActiveRecord::Schema.define(version: 20160630013339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,8 +56,8 @@ ActiveRecord::Schema.define(version: 20160619145037) do
 
   create_table "facilities", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
     t.integer  "facility_type_id"
     t.boolean  "spa"
     t.float    "acreage"
@@ -65,14 +65,13 @@ ActiveRecord::Schema.define(version: 20160619145037) do
     t.boolean  "temperture_controled"
     t.boolean  "water_features"
     t.boolean  "supplemental_feed"
-    t.integer  "facility_expertise_id"
-    t.text     "interests",             default: ["grow_herd_size"],              array: true
+    t.text     "interests",            default: ["grow_herd_size"],              array: true
     t.string   "address"
     t.float    "latitude"
     t.float    "longitude"
+    t.text     "expertise",      default: [],                              array: true
   end
 
-  add_index "facilities", ["facility_expertise_id"], name: "index_facilities_on_facility_expertise_id", using: :btree
   add_index "facilities", ["facility_type_id"], name: "index_facilities_on_facility_type_id", using: :btree
 
   create_table "facilities_users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ FacilityType.where(name: 'Institution').first_or_create
 FacilityType.where(name: 'Ranch').first_or_create
 FacilityType.where(name: 'Individual').first_or_create
 
-FacilityExpertise.where(name: 'Convervation breeding').first_or_create
+FacilityExpertise.where(name: 'Conservation breeding').first_or_create
 FacilityExpertise.where(name: 'Reproductive Science').first_or_create
 FacilityExpertise.where(name: 'Biobanking').first_or_create
 FacilityExpertise.where(name: 'Natural Resource Management').first_or_create


### PR DESCRIPTION
Addresses the following request: 

The “Facility Expertise” section is currently a drop down menu. Could it become a list of checkboxes so someone could choose more than one? (I hadn’t specified this originally.)

Also fixes a typo and removes a duplicate checkbox in the facilities form.
