### PR TITLE
Users should only be able to edit their own facilities.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,18 @@ class ApplicationController < ActionController::Base
     new_facility_path
   end
 
+  def render_unauthorized(text)
+    render_status_code(text, 401)
+  end
+
+  def render_not_found(text)
+    render_status_code(text, 404)
+  end
+
+  def render_status_code(text, code)
+    render(:text => text, :status => code, :layout => 'application') and return
+  end
+
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,9 +17,8 @@ class ApplicationController < ActionController::Base
   end
 
   def render_status_code(text, code)
-    render(:text => text, :status => code, :layout => 'application') and return
+    render(text: text, status: code, layout: 'application') && return
   end
-
 
   protected
 

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -2,7 +2,7 @@ class FacilitiesController < ApplicationController
   before_action :set_facility_user
   before_action :set_facility, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:show]
-  
+
   # GET /facilities
   # GET /facilities.json
   def index
@@ -68,10 +68,9 @@ class FacilitiesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_facility
-
-      if current_user.is_site_admin? || action_name == 'show'
+      if current_user.site_admin? || action_name == 'show'
         @facility = Facility.find(params[:id])
-      else #restrict edit/update/destroy to only facilities associated with the user.
+      else # restrict edit/update/destroy to only facilities associated with the user.
         begin
           @facility = current_user.facilities.find(params[:id])
         rescue

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -1,8 +1,8 @@
 class FacilitiesController < ApplicationController
+  before_action :set_facility_user
   before_action :set_facility, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:show]
-  before_action :set_facility_user
-
+  
   # GET /facilities
   # GET /facilities.json
   def index
@@ -68,7 +68,16 @@ class FacilitiesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_facility
-      @facility = Facility.find(params[:id])
+
+      if current_user.is_site_admin? || action_name == 'show'
+        @facility = Facility.find(params[:id])
+      else #restrict edit/update/destroy to only facilities associated with the user.
+        begin
+          @facility = current_user.facilities.find(params[:id])
+        rescue
+          render_not_found('Sorry, that facility could not be found.')
+        end
+      end
     end
 
     def set_facility_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,5 +25,9 @@ class User < ActiveRecord::Base
   def display_name
     full_name || email
   end
+
+  def is_site_admin? 
+    site_admin? 
+  end
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,9 +25,4 @@ class User < ActiveRecord::Base
   def display_name
     full_name || email
   end
-
-  def is_site_admin? 
-    site_admin? 
-  end
-  
 end


### PR DESCRIPTION
Non Admin users do not see a link to edit their own facilities. The /edit path still works, making this security merely cosmetic since any user can access the edit page for any facility. 

We have a facility_users link table we can use to filter access. Perhaps the table needs to be updated to include a facility role as well. Roles could be 'admin', 'owner', 'staff'. We can use these roles to enable/disable certain behaviors per facilities in the future. 

Even without the extra role, we can still use the table to keep non facility users out of all but the "show" action. 

This change implements the access filter for facilities. Access is restricted for anything other than the "show" action for non facility user. 

If we think this is a reasonable approach, I can keep going down this path and improve this to include the roles as well.
